### PR TITLE
Use ANTLR4 parser for Proparse schema

### DIFF
--- a/openedge-checks/src/main/java/org/sonar/plugins/openedge/api/objects/DatabaseWrapper.java
+++ b/openedge-checks/src/main/java/org/sonar/plugins/openedge/api/objects/DatabaseWrapper.java
@@ -1,0 +1,47 @@
+package org.sonar.plugins.openedge.api.objects;
+
+import java.util.Collections;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.prorefactor.core.schema.Constants;
+import org.prorefactor.core.schema.IDatabase;
+import org.prorefactor.core.schema.ITable;
+
+import eu.rssw.antlr.database.objects.DatabaseDescription;
+import eu.rssw.antlr.database.objects.Table;
+
+public class DatabaseWrapper implements IDatabase {
+  private final DatabaseDescription dbDesc;
+
+  private final SortedSet<ITable> sortedTables = new TreeSet<>(Constants.TABLE_NAME_ORDER);
+
+  public DatabaseWrapper(DatabaseDescription dbDesc) {
+    this.dbDesc = dbDesc;
+
+    for (Table fld : dbDesc.getTables()) {
+      ITable iFld = new TableWrapper(this, fld);
+      sortedTables.add(iFld);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return dbDesc.getDbName();
+  }
+
+  @Override
+  public SortedSet<ITable> getTableSet() {
+    return Collections.unmodifiableSortedSet(sortedTables);
+  }
+
+  @Override
+  public void add(ITable table) {
+    if (table.getName().startsWith("_") || table.getName().startsWith("SYS")) {
+      sortedTables.add(table);
+    } else {
+      throw new UnsupportedOperationException("Unable to add table " + table.getName());
+    }
+  }
+
+}

--- a/openedge-checks/src/main/java/org/sonar/plugins/openedge/api/objects/FieldWrapper.java
+++ b/openedge-checks/src/main/java/org/sonar/plugins/openedge/api/objects/FieldWrapper.java
@@ -1,0 +1,89 @@
+package org.sonar.plugins.openedge.api.objects;
+
+import org.prorefactor.core.JPNode;
+import org.prorefactor.core.schema.IField;
+import org.prorefactor.core.schema.ITable;
+import org.prorefactor.treeparser.DataType;
+import org.prorefactor.treeparser.Primative;
+
+import com.google.common.base.Preconditions;
+
+import eu.rssw.antlr.database.objects.Field;
+
+public class FieldWrapper implements IField {
+  private final ITable table;
+  private final Field field;
+
+  public FieldWrapper(ITable table, Field field) {
+    Preconditions.checkNotNull(table);
+    Preconditions.checkNotNull(field);
+    this.table = table;
+    this.field = field;
+  }
+
+  public Field getBackingObject() {
+    return field;
+  }
+
+  @Override
+  public String getName() {
+    return field.getName();
+  }
+
+  @Override
+  public DataType getDataType() {
+    return DataType.getDataType(field.getDataType().toUpperCase());
+  }
+
+  @Override
+  public String getClassName() {
+    // Fields can't be instances of class
+    return null;
+  }
+
+  @Override
+  public int getExtent() {
+    return field.getExtent() == null ? 0 : field.getExtent();
+  }
+
+  @Override
+  public ITable getTable() {
+    return table;
+  }
+
+  @Override
+  public IField copyBare(ITable toTable) {
+    return new FieldWrapper(toTable, field);
+  }
+
+  @Override
+  public void assignAttributesLike(Primative likePrim) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Primative setClassName(String className) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Primative setClassName(JPNode typeNameNode) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Primative setDataType(DataType dataType) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Primative setExtent(int extent) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setTable(ITable table) {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/openedge-checks/src/main/java/org/sonar/plugins/openedge/api/objects/TableWrapper.java
+++ b/openedge-checks/src/main/java/org/sonar/plugins/openedge/api/objects/TableWrapper.java
@@ -1,0 +1,84 @@
+package org.sonar.plugins.openedge.api.objects;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.prorefactor.core.IConstants;
+import org.prorefactor.core.schema.Constants;
+import org.prorefactor.core.schema.IDatabase;
+import org.prorefactor.core.schema.IField;
+import org.prorefactor.core.schema.ITable;
+import org.prorefactor.treeparser.SymbolScopeRoot;
+
+import eu.rssw.antlr.database.objects.Field;
+import eu.rssw.antlr.database.objects.Table;
+
+public class TableWrapper implements ITable {
+  private final IDatabase db;
+  private final Table table;
+
+  private final List<IField> fields = new ArrayList<>();
+  private final SortedSet<IField> sortedFields = new TreeSet<>(Constants.FIELD_NAME_ORDER);
+
+  public TableWrapper(IDatabase db, Table t) {
+    this.db = db;
+    this.table = t;
+
+    for (Field fld : table.getFields()) {
+      IField iFld = new FieldWrapper(this, fld);
+      fields.add(iFld);
+      sortedFields.add(iFld);
+    }
+  }
+
+  public Table getBackingObject() {
+    return table;
+  }
+
+  @Override
+  public IDatabase getDatabase() {
+    return db;
+  }
+
+  @Override
+  public String getName() {
+    return table.getName();
+  }
+
+  @Override
+  public void add(IField field) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public IField lookupField(String name) {
+    Field fld = table.getField(name);
+    if (fld == null)
+      return null;
+    else
+      return new FieldWrapper(this, fld);
+  }
+
+  @Override
+  public SortedSet<IField> getFieldSet() {
+    return Collections.unmodifiableSortedSet(sortedFields);
+  }
+
+  @Override
+  public List<IField> getFieldPosOrder() {
+    return Collections.unmodifiableList(fields);
+  }
+
+  @Override
+  public int getStoretype() {
+    return IConstants.ST_DBTABLE;
+  }
+
+  @Override
+  public ITable copyBare(SymbolScopeRoot scope) {
+    return new TableWrapper(db, table);
+  }
+}

--- a/proparse/src/main/java/org/prorefactor/core/schema/Constants.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/Constants.java
@@ -23,7 +23,7 @@ public class Constants {
   };
 
   /** Comparator for sorting by name. */
-  protected static final Comparator<IField> FIELD_NAME_ORDER = new Comparator<IField>() {
+  public static final Comparator<IField> FIELD_NAME_ORDER = new Comparator<IField>() {
     @Override
     public int compare(IField f1, IField f2) {
       return f1.getName().compareToIgnoreCase(f2.getName());

--- a/proparse/src/main/java/org/prorefactor/core/schema/Constants.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/Constants.java
@@ -1,0 +1,36 @@
+package org.prorefactor.core.schema;
+
+import java.util.Comparator;
+
+public class Constants {
+  public static final IDatabase nullDatabase = new Database("");
+  public static final ITable nullTable = new Table("");
+
+  /** Comparator for sorting by name. */
+  public static final Comparator<IDatabase> DB_NAME_ORDER = new Comparator<IDatabase>() {
+    @Override
+    public int compare(IDatabase d1, IDatabase d2) {
+      return d1.getName().compareToIgnoreCase(d2.getName());
+    }
+  };
+
+  /** Comparator for sorting by name. */
+  public static final Comparator<ITable> TABLE_NAME_ORDER = new Comparator<ITable>() {
+    @Override
+    public int compare(ITable t1, ITable t2) {
+      return t1.getName().compareToIgnoreCase(t2.getName());
+    }
+  };
+
+  /** Comparator for sorting by name. */
+  protected static final Comparator<IField> FIELD_NAME_ORDER = new Comparator<IField>() {
+    @Override
+    public int compare(IField f1, IField f2) {
+      return f1.getName().compareToIgnoreCase(f2.getName());
+    }
+  };
+
+  private Constants() {
+    // No-op
+  }
+}

--- a/proparse/src/main/java/org/prorefactor/core/schema/Database.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/Database.java
@@ -10,7 +10,6 @@
  *******************************************************************************/ 
 package org.prorefactor.core.schema;
 
-import java.util.Comparator;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -19,17 +18,9 @@ import java.util.TreeSet;
  * units. "id" field is a database number, starting at one. Might be the logical database number - depends on how you
  * use this.
  */
-public class Database {
-  /** Comparator for sorting by name. */
-  public static final Comparator<Database> NAME_ORDER = new Comparator<Database>() {
-    @Override
-    public int compare(Database d1, Database d2) {
-      return d1.getName().compareToIgnoreCase(d2.getName());
-    }
-  };
-
+public class Database implements IDatabase {
   private final String name;
-  private final SortedSet<Table> tableSet = new TreeSet<>(Table.NAME_ORDER);
+  private final SortedSet<ITable> tableSet = new TreeSet<>(Constants.TABLE_NAME_ORDER);
 
   /**
    * New Database object
@@ -43,15 +34,18 @@ public class Database {
    * Add new Table object
    * @param table
    */
-  public void add(Table table) {
+  @Override
+  public void add(ITable table) {
     tableSet.add(table);
   }
 
+  @Override
   public String getName() {
     return name;
   }
 
-  public SortedSet<Table> getTableSet() {
+  @Override
+  public SortedSet<ITable> getTableSet() {
     return tableSet;
   }
 

--- a/proparse/src/main/java/org/prorefactor/core/schema/Field.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/Field.java
@@ -10,8 +10,6 @@
  *******************************************************************************/ 
 package org.prorefactor.core.schema;
 
-import java.util.Comparator;
-
 import org.prorefactor.core.JPNode;
 import org.prorefactor.treeparser.ClassSupport;
 import org.prorefactor.treeparser.DataType;
@@ -21,20 +19,12 @@ import org.prorefactor.treeparser.Primative;
  * Field objects are created both by the Schema class and they are also created for temp and work table fields defined
  * within a 4gl compile unit.
  */
-public class Field implements Primative {
-  /** Comparator for sorting by name. */
-  protected static final Comparator<Field> NAME_ORDER = new Comparator<Field>() {
-    @Override
-    public int compare(Field f1, Field f2) {
-      return f1.name.compareToIgnoreCase(f2.name);
-    }
-  };
-
+public class Field implements IField {
   private final String name;
   private int extent;
   private DataType dataType;
   private String className = null;
-  private Table table;
+  private ITable table;
 
   /**
    * Standard constructor.
@@ -42,7 +32,7 @@ public class Field implements Primative {
    * @param table Use null if you want to assign the field to a table as a separate step.
    * @see #setTable(Table)
    */
-  public Field(String inName, Table table) {
+  public Field(String inName, ITable table) {
     this.name = inName;
     this.table = table;
     if (table != null)
@@ -52,7 +42,7 @@ public class Field implements Primative {
   /** Constructor for temporary "lookup" fields. "Package" visibility. */
   Field(String inName) {
     this.name = inName;
-    this.table = Schema.nullTable;
+    this.table = Constants.nullTable;
   }
 
   @Override
@@ -69,7 +59,8 @@ public class Field implements Primative {
    * @return The newly created Field, though you may not need it for anything since it has already been added to the
    *         Table.
    */
-  public Field copyBare(Table toTable) {
+  @Override
+  public IField copyBare(ITable toTable) {
     Field f = new Field(this.name, toTable);
     f.dataType = this.dataType;
     f.extent = this.extent;
@@ -92,11 +83,13 @@ public class Field implements Primative {
     return extent;
   }
 
+  @Override
   public String getName() {
     return name;
   }
 
-  public Table getTable() {
+  @Override
+  public ITable getTable() {
     return table;
   }
 
@@ -125,7 +118,8 @@ public class Field implements Primative {
   }
 
   /** Use this to set the field to a table if you used null for the table in the constructor. */
-  public void setTable(Table table) {
+  @Override
+  public void setTable(ITable table) {
     this.table = table;
     table.add(this);
   }

--- a/proparse/src/main/java/org/prorefactor/core/schema/IDatabase.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/IDatabase.java
@@ -1,0 +1,9 @@
+package org.prorefactor.core.schema;
+
+import java.util.SortedSet;
+
+public interface IDatabase {
+  public void add(ITable table);
+  public String getName();
+  public SortedSet<ITable> getTableSet();
+}

--- a/proparse/src/main/java/org/prorefactor/core/schema/IField.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/IField.java
@@ -1,0 +1,10 @@
+package org.prorefactor.core.schema;
+
+import org.prorefactor.treeparser.Primative;
+
+public interface IField extends Primative {
+  String getName();
+  IField copyBare(ITable toTable);
+  ITable getTable();
+  void setTable(ITable table);
+}

--- a/proparse/src/main/java/org/prorefactor/core/schema/ISchema.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/ISchema.java
@@ -15,7 +15,6 @@ package org.prorefactor.core.schema;
  * Represents the list of all available db, aliases and tables in an OpenEdge session
  */
 public interface ISchema {
-
   /**
    * Add a database alias.
    * 
@@ -36,7 +35,7 @@ public interface ISchema {
    * @param name Database name
    * @return Null if not found
    */
-  Database lookupDatabase(String name);
+  IDatabase lookupDatabase(String name);
 
   /**
    * Lookup a Field, given the db, table, and field names
@@ -45,7 +44,7 @@ public interface ISchema {
    * @param fieldName
    * @return
    */
-  Field lookupField(String dbName, String tableName, String fieldName);
+  IField lookupField(String dbName, String tableName, String fieldName);
 
   /**
    * Lookup a table by name.
@@ -55,10 +54,10 @@ public interface ISchema {
    *         dictdb for the table, in case it's something like "sports._file". In that case, the Table from the "dictdb"
    *         database would be returned. We don't keep meta-schema records in the rest of the databases.
    */
-  Table lookupTable(String inName);
+  ITable lookupTable(String inName);
 
   /** Lookup a table, given a database name and a table name. */
-  Table lookupTable(String dbName, String tableName);
+  ITable lookupTable(String dbName, String tableName);
 
   /**
    * Lookup an unqualified schema field name. Does not test for uniqueness. That job is left to the compiler. In fact,
@@ -67,5 +66,5 @@ public interface ISchema {
    * @param name Unqualified schema field name
    * @return Null if nothing found
    */
-  Field lookupUnqualifiedField(String name);
+  IField lookupUnqualifiedField(String name);
 }

--- a/proparse/src/main/java/org/prorefactor/core/schema/ITable.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/ITable.java
@@ -8,13 +8,33 @@ import org.prorefactor.treeparser.SymbolScopeRoot;
 public interface ITable {
   IDatabase getDatabase();
   String getName();
+
+  /**
+   * Lookup a field by name. We do not test for uniqueness. We leave that job to the compiler. This function expects an
+   * unqualified field name (no name dots).
+   */
   IField lookupField(String name);
+
+  /** Add a Field to this table. "Package" visibility only. */
   void add(IField field);
+
   SortedSet<IField> getFieldSet();
+
+  /**
+   * Get the ArrayList of fields in field position order (rather than sorted alpha)
+   */
   List<IField> getFieldPosOrder();
 
   // TODO Document return values
   int getStoretype();
+
+  /**
+   * Create a bare minimum copy of a Table definition. No-op if the table already exists in the requested scope. Copies
+   * all of the field definitions as well.
+   * 
+   * @param scope The scope that this table is to be added to.
+   * @return The newly created table, or the existing one from the scope if it has previously been defined.
+   */
   // TODO Remove dependency
   ITable copyBare(SymbolScopeRoot scope);
 }

--- a/proparse/src/main/java/org/prorefactor/core/schema/ITable.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/ITable.java
@@ -1,0 +1,20 @@
+package org.prorefactor.core.schema;
+
+import java.util.List;
+import java.util.SortedSet;
+
+import org.prorefactor.treeparser.SymbolScopeRoot;
+
+public interface ITable {
+  IDatabase getDatabase();
+  String getName();
+  IField lookupField(String name);
+  void add(IField field);
+  SortedSet<IField> getFieldSet();
+  List<IField> getFieldPosOrder();
+
+  // TODO Document return values
+  int getStoretype();
+  // TODO Remove dependency
+  ITable copyBare(SymbolScopeRoot scope);
+}

--- a/proparse/src/main/java/org/prorefactor/core/schema/Table.java
+++ b/proparse/src/main/java/org/prorefactor/core/schema/Table.java
@@ -49,20 +49,12 @@ public class Table implements ITable {
     database = Constants.nullDatabase;
   }
 
-  /** Add a Field to this table. "Package" visibility only. */
   @Override
   public void add(IField field) {
     fieldSet.add(field);
     fieldPosOrder.add(field);
   }
 
-  /**
-   * Create a bare minimum copy of a Table definition. No-op if the table already exists in the requested scope. Copies
-   * all of the field definitions as well.
-   * 
-   * @param scope The scope that this table is to be added to.
-   * @return The newly created table, or the existing one from the scope if it has previously been defined.
-   */
   public ITable copyBare(SymbolScopeRoot scope) {
     ITable t = scope.lookupTableDefinition(this.name);
     if (t != null)
@@ -79,7 +71,6 @@ public class Table implements ITable {
     return database;
   }
 
-  /** Get the ArrayList of fields in field position order (rather than sorted alpha). */
   @Override
   public List<IField> getFieldPosOrder() {
     return fieldPosOrder;
@@ -100,10 +91,6 @@ public class Table implements ITable {
     return storetype;
   }
 
-  /**
-   * Lookup a field by name. We do not test for uniqueness. We leave that job to the compiler. This function expects an
-   * unqualified field name (no name dots).
-   */
   @Override
   public IField lookupField(String lookupName) {
     SortedSet<IField> fieldTailSet = fieldSet.tailSet(new Field(lookupName));

--- a/proparse/src/main/java/org/prorefactor/proparse/SymbolScope.java
+++ b/proparse/src/main/java/org/prorefactor/proparse/SymbolScope.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.prorefactor.core.NodeTypes;
+import org.prorefactor.core.schema.ITable;
 import org.prorefactor.core.schema.Table;
 import org.prorefactor.refactor.RefactorSession;
 
@@ -55,7 +56,7 @@ public class SymbolScope {
     newRef.tableType = bufferType;
     tableMap.put(bufferName, newRef);
     if (newRef.tableType == FieldType.DBTABLE) {
-      Table table = session.getSchema().lookupTable(tableName);
+      ITable table = session.getSchema().lookupTable(tableName);
       if (table != null) {
         newRef.dbName = table.getDatabase().getName();
         newRef.fullName = newRef.dbName + "." + table.getName();
@@ -104,7 +105,7 @@ public class SymbolScope {
   FieldType isTable(String inName) {
     // isTable is not recursive, but isTableDef is.
     // First: Qualified db.table.
-    Table table = session.getSchema().lookupTable(inName);
+    ITable table = session.getSchema().lookupTable(inName);
     if (table != null && inName.contains("."))
       return FieldType.DBTABLE;
     // Second: temp-table/work-table/buffer name.
@@ -140,7 +141,7 @@ public class SymbolScope {
   FieldType isTableSchemaFirst(String inName) {
     // If we find that an non-abbreviated schema table name matches,
     // we return it even before a temp/work table match.
-    Table table = session.getSchema().lookupTable(inName);
+    ITable table = session.getSchema().lookupTable(inName);
     if (table != null) {
       Table.Name name = new Table.Name(inName);
       if (table.getName().length() == name.getTable().length())

--- a/proparse/src/main/java/org/prorefactor/refactor/RefactorSession.java
+++ b/proparse/src/main/java/org/prorefactor/refactor/RefactorSession.java
@@ -15,7 +15,7 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.prorefactor.core.schema.Schema;
+import org.prorefactor.core.schema.ISchema;
 import org.prorefactor.proparse.SymbolScope;
 import org.prorefactor.refactor.settings.IProparseSettings;
 
@@ -27,17 +27,17 @@ import com.google.inject.Inject;
  */
 public class RefactorSession {
   private final IProparseSettings proparseSettings;
-  private final Schema schema;
+  private final ISchema schema;
   private final Charset charset;
 
   private final Map<String, SymbolScope> superCache = new HashMap<>();
 
   @Inject
-  public RefactorSession(IProparseSettings proparseSettings, Schema schema) {
+  public RefactorSession(IProparseSettings proparseSettings, ISchema schema) {
     this(proparseSettings, schema, Charset.defaultCharset());
   }
 
-  public RefactorSession(IProparseSettings proparseSettings, Schema schema,
+  public RefactorSession(IProparseSettings proparseSettings, ISchema schema,
       Charset charset) {
     this.proparseSettings = proparseSettings;
     this.schema = schema;
@@ -69,7 +69,7 @@ public class RefactorSession {
     return superCache.get(superName.toLowerCase());
   }
 
-  public Schema getSchema() {
+  public ISchema getSchema() {
     return schema;
   }
 

--- a/proparse/src/main/java/org/prorefactor/treeparser/Block.java
+++ b/proparse/src/main/java/org/prorefactor/treeparser/Block.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.prorefactor.core.JPNode;
 import org.prorefactor.core.NodeTypes;
 import org.prorefactor.core.nodetypes.RecordNameNode;
-import org.prorefactor.core.schema.Field;
+import org.prorefactor.core.schema.IField;
 import org.prorefactor.widgettypes.Frame;
 
 /**
@@ -341,7 +341,7 @@ public class Block {
       // amongst all schema and temp/work tables. We don't check for
       // uniqueness, we just take the first we find.
       if (result == null) {
-        Field field;
+        IField field;
         result = new FieldLookupResult();
         field = symbolScope.getRootScope().lookupUnqualifiedField(name);
         if (field != null) {
@@ -363,7 +363,7 @@ public class Block {
       tableBuff = symbolScope.getBufferSymbol(tablePart);
       if (tableBuff == null)
         return null;
-      Field field = tableBuff.getTable().lookupField(fieldPart);
+      IField field = tableBuff.getTable().lookupField(fieldPart);
       if (field == null)
         return null;
       result.field = tableBuff.getFieldBuffer(field);
@@ -414,7 +414,7 @@ public class Block {
       // Weak scoped named buffers don't get raised for field references.
       if (buffScope.isWeak() && !isBufferLocal(buffScope) && !tableBuff.isDefault())
         continue;
-      Field field = tableBuff.getTable().lookupField(name);
+      IField field = tableBuff.getTable().lookupField(name);
       if (field == null)
         continue;
       // The buffers aren't sorted, but "named" buffers and temp/work

--- a/proparse/src/main/java/org/prorefactor/treeparser/FieldBuffer.java
+++ b/proparse/src/main/java/org/prorefactor/treeparser/FieldBuffer.java
@@ -13,7 +13,8 @@ package org.prorefactor.treeparser;
 import org.prorefactor.core.JPNode;
 import org.prorefactor.core.NodeTypes;
 import org.prorefactor.core.schema.Field;
-import org.prorefactor.core.schema.Schema;
+import org.prorefactor.core.schema.IField;
+import org.prorefactor.core.schema.ISchema;
 
 /**
  * FieldBuffer is the Symbol object linked to from the AST for schema, temp, and work table fields, and FieldBuffer
@@ -21,12 +22,12 @@ import org.prorefactor.core.schema.Schema;
  */
 public class FieldBuffer extends Symbol implements Primative {
   private final TableBuffer buffer;
-  private final Field field;
+  private final IField field;
 
   /**
    * When you create a FieldBuffer object, you do not set the name, because that comes from the Field object.
    */
-  public FieldBuffer(SymbolScope scope, TableBuffer buffer, Field field) {
+  public FieldBuffer(SymbolScope scope, TableBuffer buffer, IField field) {
     super("", scope);
     this.buffer = buffer;
     this.field = field;
@@ -47,7 +48,7 @@ public class FieldBuffer extends Symbol implements Primative {
     assert input.generateName().toLowerCase().equals(input.generateName());
     Field.Name self = new Field.Name(this.fullName().toLowerCase());
     if (input.getDb() != null) {
-      Schema schema = getScope().getRootScope().getRefactorSession().getSchema();
+      ISchema schema = getScope().getRootScope().getRefactorSession().getSchema();
       if (this.buffer.getTable().getDatabase() != schema.lookupDatabase(input.getDb()))
         return false;
     }
@@ -115,7 +116,7 @@ public class FieldBuffer extends Symbol implements Primative {
     return field.getExtent();
   }
 
-  public Field getField() {
+  public IField getField() {
     return field;
   }
 
@@ -130,7 +131,7 @@ public class FieldBuffer extends Symbol implements Primative {
    * 
    * @see org.prorefactor.treeparser.Symbol#getProgressType() To see if this field buffer is for a schema table,
    *      temp-table, or work-table, see Table.getStoreType().
-   * @see org.prorefactor.core.schema.Table#getStoretype()
+   * @see org.prorefactor.core.schema.ITable#getStoretype()
    */
   @Override
   public int getProgressType() {

--- a/proparse/src/main/java/org/prorefactor/treeparser/SymbolScope.java
+++ b/proparse/src/main/java/org/prorefactor/treeparser/SymbolScope.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.prorefactor.core.IConstants;
 import org.prorefactor.core.NodeTypes;
+import org.prorefactor.core.schema.ITable;
 import org.prorefactor.core.schema.Table;
 import org.prorefactor.widgettypes.IFieldLevelWidget;
 
@@ -43,7 +44,7 @@ public class SymbolScope {
   protected Map<String, TableBuffer> bufferMap = new HashMap<>();
   protected Map<String, IFieldLevelWidget> fieldLevelWidgetMap = new HashMap<>();
   protected Map<String, Routine> routineMap = new HashMap<>();
-  protected Map<Table, TableBuffer> unnamedBuffers = new HashMap<>();
+  protected Map<ITable, TableBuffer> unnamedBuffers = new HashMap<>();
   protected Map<Integer, Map<String, Symbol>> typeMap = new HashMap<>();
   protected Map<String, Variable> variableMap = new HashMap<>();
 
@@ -86,7 +87,7 @@ public class SymbolScope {
    * purposes.
    */
   public void add(TableBuffer tableBuffer) {
-    Table table = tableBuffer.getTable();
+    ITable table = tableBuffer.getTable();
     addTableBuffer(tableBuffer.getName(), table, tableBuffer);
     rootScope.addTableDefinitionIfNew(table);
   }
@@ -133,7 +134,7 @@ public class SymbolScope {
   }
 
   /** Add a TableBuffer to the appropriate map. */
-  private void addTableBuffer(String name, Table table, TableBuffer buffer) {
+  private void addTableBuffer(String name, ITable table, TableBuffer buffer) {
     if (name.length() == 0) {
       if (table.getStoretype() == IConstants.ST_DBTABLE)
         unnamedBuffers.put(table, buffer);
@@ -148,7 +149,7 @@ public class SymbolScope {
    * 
    * @param name Input "" for a default or unnamed buffer, otherwise the "named buffer" name.
    */
-  public TableBuffer defineBuffer(String name, Table table) {
+  public TableBuffer defineBuffer(String name, ITable table) {
     TableBuffer buffer = new TableBuffer(name, this, table);
     addTableBuffer(name, table, buffer);
     return buffer;
@@ -216,7 +217,7 @@ public class SymbolScope {
     // The default buffer for temp and work tables was defined at
     // the time that the table was defined. So, lookupBuffer() would have found
     // temp/work table references, and all we have to search now is schema.
-    Table table = rootScope.getRefactorSession().getSchema().lookupTable(inName);
+    ITable table = rootScope.getRefactorSession().getSchema().lookupTable(inName);
     if (table == null)
       return null;
     return getUnnamedBuffer(table);
@@ -254,7 +255,7 @@ public class SymbolScope {
   }
 
   /** Get or create the unnamed buffer for a schema table. */
-  public TableBuffer getUnnamedBuffer(Table table) {
+  public TableBuffer getUnnamedBuffer(ITable table) {
     assert table.getStoretype() == IConstants.ST_DBTABLE;
     // Check this and parents for the unnamed buffer. Table triggers
     // can scope an unnamed buffer - that's why we don't go straight to
@@ -383,7 +384,7 @@ public class SymbolScope {
    * buffer/temp/work name, then abbreviated schema names. Sheesh.
    */
   public TableBuffer lookupTableOrBufferSymbol(String inName) {
-    Table table = rootScope.getRefactorSession().getSchema().lookupTable(inName);
+    ITable table = rootScope.getRefactorSession().getSchema().lookupTable(inName);
     if (table != null && table.getName().length() == inName.length())
       return getUnnamedBuffer(table);
     TableBuffer ret2 = lookupBuffer(inName);

--- a/proparse/src/main/java/org/prorefactor/treeparser/TableBuffer.java
+++ b/proparse/src/main/java/org/prorefactor/treeparser/TableBuffer.java
@@ -16,23 +16,23 @@ import java.util.Map;
 
 import org.prorefactor.core.IConstants;
 import org.prorefactor.core.NodeTypes;
-import org.prorefactor.core.schema.Field;
-import org.prorefactor.core.schema.Table;
+import org.prorefactor.core.schema.IField;
+import org.prorefactor.core.schema.ITable;
 
 /**
  * A TableBuffer is a Symbol which provides a link from the syntax tree to a Table object.
  */
 public class TableBuffer extends Symbol {
-  private final Table table;
+  private final ITable table;
   private final boolean isDefault;
-  private final Map<Field, FieldBuffer> fieldBuffers = new HashMap<>();
+  private final Map<IField, FieldBuffer> fieldBuffers = new HashMap<>();
 
   /**
    * Constructor for a named buffer.
    * 
    * @param name Input "" for an unnamed or default buffer
    */
-  public TableBuffer(String name, SymbolScope scope, Table table) {
+  public TableBuffer(String name, SymbolScope scope, ITable table) {
     super(name, scope);
     this.table = table;
     this.isDefault = name.isEmpty();
@@ -45,7 +45,7 @@ public class TableBuffer extends Symbol {
   /** For temp/work table, also adds Table definition to the scope if it doesn't already exist. */
   @Override
   public Symbol copyBare(SymbolScope scope) {
-    Table t;
+    ITable t;
     if (this.table.getStoretype() == IConstants.ST_DBTABLE) {
       t = this.table;
     } else {
@@ -79,7 +79,7 @@ public class TableBuffer extends Symbol {
    * Always returns BUFFER, whether this is a named buffer or a default buffer.
    * 
    * @see org.prorefactor.treeparser.Symbol#getProgressType()
-   * @see org.prorefactor.core.schema.Table#getStoretype()
+   * @see org.prorefactor.core.schema.ITable#getStoretype()
    */
   @Override
   public int getProgressType() {
@@ -87,7 +87,7 @@ public class TableBuffer extends Symbol {
   }
 
   /** Get or create a FieldBuffer for a Field. */
-  public FieldBuffer getFieldBuffer(Field field) {
+  public FieldBuffer getFieldBuffer(IField field) {
     assert field.getTable() == this.table;
     FieldBuffer ret = fieldBuffers.get(field);
     if (ret != null)
@@ -109,7 +109,7 @@ public class TableBuffer extends Symbol {
     return super.getName();
   }
 
-  public Table getTable() {
+  public ITable getTable() {
     return table;
   }
 

--- a/proparse/src/main/java/org/prorefactor/treeparser01/FrameStack.java
+++ b/proparse/src/main/java/org/prorefactor/treeparser01/FrameStack.java
@@ -22,6 +22,7 @@ import org.prorefactor.core.nodetypes.BlockNode;
 import org.prorefactor.core.nodetypes.FieldRefNode;
 import org.prorefactor.core.nodetypes.RecordNameNode;
 import org.prorefactor.core.schema.Field;
+import org.prorefactor.core.schema.IField;
 import org.prorefactor.treeparser.Block;
 import org.prorefactor.treeparser.FieldBuffer;
 import org.prorefactor.treeparser.FieldContainer;
@@ -76,17 +77,17 @@ public class FrameStack {
     assert formItemNode.firstChild().getType() == NodeTypes.RECORD_NAME;
     RecordNameNode recordNameNode = (RecordNameNode) formItemNode.firstChild();
     TableBuffer tableBuffer = recordNameNode.getTableBuffer();
-    HashSet<Field> fieldSet = new HashSet<>(tableBuffer.getTable().getFieldSet());
+    HashSet<IField> fieldSet = new HashSet<>(tableBuffer.getTable().getFieldSet());
     JPNode exceptNode = formItemNode.getParent().findDirectChild(NodeTypes.EXCEPT);
     if (exceptNode != null)
       for (JPNode n = exceptNode.firstChild(); n != null; n = n.nextSibling()) {
         if (!(n instanceof FieldRefNode))
           continue;
-        Field f = ((FieldBuffer) ((FieldRefNode) n).getSymbol()).getField();
+        IField f = ((FieldBuffer) ((FieldRefNode) n).getSymbol()).getField();
         fieldSet.remove(f);
       }
     ArrayList<FieldBuffer> returnList = new ArrayList<>();
-    for (Field field : fieldSet) {
+    for (IField field : fieldSet) {
       returnList.add(tableBuffer.getFieldBuffer(field));
     }
     return returnList;

--- a/proparse/src/test/java/org/prorefactor/core/unittest/util/UnitTestBackslashModule.java
+++ b/proparse/src/test/java/org/prorefactor/core/unittest/util/UnitTestBackslashModule.java
@@ -10,7 +10,7 @@
  *******************************************************************************/ 
 package org.prorefactor.core.unittest.util;
 
-import org.prorefactor.core.schema.Schema;
+import org.prorefactor.core.schema.ISchema;
 import org.prorefactor.refactor.settings.IProparseSettings;
 
 import com.google.inject.AbstractModule;
@@ -19,6 +19,6 @@ public class UnitTestBackslashModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(IProparseSettings.class).to(UnitTestBackslashProparseSettings.class);
-    bind(Schema.class).to(SportsSchema.class);
+    bind(ISchema.class).to(SportsSchema.class);
   }
 }

--- a/proparse/src/test/java/org/prorefactor/core/unittest/util/UnitTestModule.java
+++ b/proparse/src/test/java/org/prorefactor/core/unittest/util/UnitTestModule.java
@@ -10,7 +10,7 @@
  *******************************************************************************/ 
 package org.prorefactor.core.unittest.util;
 
-import org.prorefactor.core.schema.Schema;
+import org.prorefactor.core.schema.ISchema;
 import org.prorefactor.refactor.settings.IProparseSettings;
 
 import com.google.inject.AbstractModule;
@@ -19,6 +19,6 @@ public class UnitTestModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(IProparseSettings.class).to(UnitTestProparseSettings.class);
-    bind(Schema.class).to(SportsSchema.class);
+    bind(ISchema.class).to(SportsSchema.class);
   }
 }


### PR DESCRIPTION
Schema was previously read using ANTLR4, then written to disk using the Proparse format, then read from disk using Proparse methods.
Huge overhead for large schemas, made visible in SonarLint for Eclipse